### PR TITLE
fix: joaat calculator

### DIFF
--- a/src/components/Joaat/Joaat.jsx
+++ b/src/components/Joaat/Joaat.jsx
@@ -22,8 +22,6 @@ function JOAATCalculator() {
     h ^= (h >>> 11);
     h += (h << 15);
 
-    console.log(h);
-
     setUint32Result(h >>> 0);
     setInt32Result(h | 0);
     setHexResult((h >>> 0).toString(16).toUpperCase())

--- a/src/components/Joaat/Joaat.jsx
+++ b/src/components/Joaat/Joaat.jsx
@@ -10,9 +10,9 @@ function JOAATCalculator() {
 
   const calculateJOAAT = (str) => {
     str = str.toLowerCase();
-    let hash, i;
+    let hash = 0;
 
-    for (hash = i = 0; i < str.length; i++) {
+    for (let i = 0; i < str.length; i++) {
       hash += str.charCodeAt(i);
       hash += (hash << 10);
       hash ^= (hash >>> 6);
@@ -24,7 +24,7 @@ function JOAATCalculator() {
 
     setUint32Result(hash >>> 0);
     setInt32Result(hash | 0);
-    setHexResult((hash >>> 0).toString(16).toUpperCase())
+    setHexResult((hash >>> 0).toString(16).toUpperCase());
 
     if (str.toLowerCase() === 'karby') {
       setShowKarby(true);

--- a/src/components/Joaat/Joaat.jsx
+++ b/src/components/Joaat/Joaat.jsx
@@ -10,21 +10,21 @@ function JOAATCalculator() {
 
   const calculateJOAAT = (str) => {
     str = str.toLowerCase();
-    let h, i;
+    let hash, i;
 
-    for (h = i = 0; i < str.length; i++) {
-      h += str.charCodeAt(i);
-      h += (h << 10);
-      h ^= (h >>> 6);
+    for (hash = i = 0; i < str.length; i++) {
+      hash += str.charCodeAt(i);
+      hash += (hash << 10);
+      hash ^= (hash >>> 6);
     }
 
-    h += (h << 3);
-    h ^= (h >>> 11);
-    h += (h << 15);
+    hash += (hash << 3);
+    hash ^= (hash >>> 11);
+    hash += (hash << 15);
 
-    setUint32Result(h >>> 0);
-    setInt32Result(h | 0);
-    setHexResult((h >>> 0).toString(16).toUpperCase())
+    setUint32Result(hash >>> 0);
+    setInt32Result(hash | 0);
+    setHexResult((hash >>> 0).toString(16).toUpperCase())
 
     if (str.toLowerCase() === 'karby') {
       setShowKarby(true);

--- a/src/components/Joaat/Joaat.jsx
+++ b/src/components/Joaat/Joaat.jsx
@@ -9,22 +9,24 @@ function JOAATCalculator() {
   const [showKarby, setShowKarby] = useState(false);
 
   const calculateJOAAT = (str) => {
-    let hash = 0;
+    str = str.toLowerCase();
+    let h, i;
 
-    for (let i = 0; i < str.length; i++) {
-      const char = str.charCodeAt(i);
-      hash += char;
-      hash += (hash << 10);
-      hash ^= (hash >>> 6);
+    for (h = i = 0; i < str.length; i++) {
+      h += str.charCodeAt(i);
+      h += (h << 10);
+      h ^= (h >>> 6);
     }
 
-    hash += (hash << 3);
-    hash ^= (hash >>> 11);
-    hash += (hash << 15);
+    h += (h << 3);
+    h ^= (h >>> 11);
+    h += (h << 15);
 
-    setUint32Result(hash >>> 0);
-    setInt32Result(hash | 0);
-    setHexResult((hash >>> 0).toString(16).toUpperCase());
+    console.log(h);
+
+    setUint32Result(h >>> 0);
+    setInt32Result(h | 0);
+    setHexResult((h >>> 0).toString(16).toUpperCase())
 
     if (str.toLowerCase() === 'karby') {
       setShowKarby(true);


### PR DESCRIPTION
The current version of joaat caclulator is invalid.

<img src="https://github.com/altmp/altv-docs-new/assets/51422045/03b7980f-3f4d-4d0f-97f7-2fd61b75a330" height="300px" />

Here is ingame api result and the old website result for the same string.

![image](https://github.com/altmp/altv-docs-new/assets/51422045/3030c30e-8403-43e8-ba26-b9ab5a8b7683)

<img src="https://github.com/altmp/altv-docs-new/assets/51422045/c35a3cbd-c138-4358-b453-56b1c3f67a4c" width="300px" />


